### PR TITLE
Fix: Auth Callback Redirect (Final)

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,1 +1,30 @@
-.*
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { createClient } from "@/utils/supabase/server";
+
+export async function GET() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return redirect("/signup");
+  }
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("household_id, name")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.household_id) {
+    return redirect("/onboarding/household");
+  }
+
+  if (!profile?.name) {
+    return redirect("/onboarding/profile");
+  }
+
+  return redirect("/dashboard");
+}


### PR DESCRIPTION
Ersetzt die fehlerhafte `route.ts` durch eine funktionierende Version mit klarer Weiterleitung nach Profilstatus. Verwendet `createClient` aus `@/utils/supabase/server` und behebt damit das Login-Redirect-Problem endgültig.